### PR TITLE
Support to obtain the image in an object (serializable in JSON format)

### DIFF
--- a/qrcode.js
+++ b/qrcode.js
@@ -464,17 +464,15 @@ exports.qrcode = function() {
 			} );
 
       return {
-        attributes: {
-          width: size,
-          height: size
-        },
+        width: size,
+        height: size,
         src: img
       } 
 		};
 
     _this.createImgTag = function(cellsize, margin){
       var img = this.createImg(cellsize, margin);
-      return createImgTag(img.attributes.width, img.attributes.height, img.src);
+      return createImgTag(img.width, img.height, img.src);
     };
 
 		return _this;


### PR DESCRIPTION
I don't know if it's really useful, but, with these commits, it's possible to obtain not only an `<img>` or a `<table>` tags but also an object (serializable to JSON in a HTTP response) whose properties are the attributes of the `<img>` tag. It could be good for generating Backbone.js Views, for example. In order to do this, a new function was added: `qrcode.createImg(cellSize, margin)`.

Also, there's no need to use the `base64EncodeOutputStream` function, as it can be replaced with a `Buffer` class. I thought it could lead to a performance improvement but finally, it couldn't.

I specially like this module because is independent from other modules such as node-canvas that can be a pain in the ass.
